### PR TITLE
Fix loading and older emacs issues

### DIFF
--- a/help-find.el
+++ b/help-find.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 'help-mode)
 
 (define-button-type 'help-find-keymap
   :supertype 'help-xref
@@ -129,7 +130,9 @@ This searches all keymaps in the global `obarray'."
                                   'type 'help-find-keymap
                                   'help-args (list (car it)))
               (indent-to 40 1)
-              (insert (help--key-description-fontified keys))
+              (insert (propertize (key-description keys)
+                                  'font-lock-face 'help-key-binding
+                                  'face 'help-key-binding))
               (princ "\n"))
             (cdr it))
            bindings))))))


### PR DESCRIPTION
- load help-mode for loading 'help-xref button type
- replace help--key-description-fontified for older emacs
  - help--key-description-fontified was introduced at Emacs 28

byte-compile on older emacs

```
help-find.el:177:1:Warning: the function ‘help--key-description-fontified’ is
    not known to be defined
```

load error at loading if help-mode is not loaded

```
Loading /tmp/help-find/help-find.el (source)...
Load error for /tmp/help-find/help-find.el:
(error Unknown button type ‘help-xref’)
```